### PR TITLE
Change PHP keywords to comply with PSR2

### DIFF
--- a/tests/fixtures/Config/sample-config.php
+++ b/tests/fixtures/Config/sample-config.php
@@ -15,7 +15,7 @@ return array(
 
     'debug' => true,
 
-    'debugAgain' => FALSE,
+    'debugAgain' => false,
 
     'bullyIan' => 0,
 


### PR DESCRIPTION
Hi, I've changed a PHP keyword to comply with [this standard](https://www.php-fig.org/psr/psr-2/#25-keywords-and-truefalsenull) in PSR2. It's admittedly a small fix but I hope it helps!