### PR TITLE
Rewrite config files with env calls

### DIFF
--- a/src/DataWriter/Rewrite.php
+++ b/src/DataWriter/Rewrite.php
@@ -19,6 +19,7 @@ use Exception;
  * - booleans
  * - nulls
  * - single-dimension arrays
+ * - default values in env function calls
  *
  * To do:
  * - When an entry does not exist, provide a way to create it
@@ -87,14 +88,15 @@ class Rewrite
         $replaceValue = $this->writeValueToPhp($value);
 
         $count = 0;
-        $patterns = [];
-        $patterns[] = $this->buildStringExpression($key, $items);
-        $patterns[] = $this->buildStringExpression($key, $items, '"');
-        $patterns[] = $this->buildConstantExpression($key, $items);
-        $patterns[] = $this->buildArrayExpression($key, $items);
+        $patterns = array();
+        $patterns[$this->buildStringExpression($key, $items)] = '${1}${2}'.$replaceValue;
+        $patterns[$this->buildStringExpression($key, $items, '"')] = '${1}${2}'.$replaceValue;
+        $patterns[$this->buildEnvCallExpression($key, $items)] = '${1}${2}${4}' . $replaceValue . '${8}';
+        $patterns[$this->buildConstantExpression($key, $items)] = '${1}${2}'.$replaceValue;
+        $patterns[$this->buildArrayExpression($key, $items)] = '${1}${2}'.$replaceValue;
 
-        foreach ($patterns as $pattern) {
-            $result = preg_replace($pattern, '${1}${2}' . $replaceValue, $result, 1, $count);
+        foreach ($patterns as $pattern => $patternReplacement) {
+            $result = preg_replace($pattern, $patternReplacement, $result, 1, $count);
 
             if ($count > 0) {
                 break;
@@ -160,6 +162,22 @@ class Rewrite
 
         // The target key closure
         $expression[] = '['.$quoteChar.']';
+
+        return '/' . implode('', $expression) . '/';
+    }
+
+    protected function buildEnvCallExpression(string $targetKey, array $arrayItems = [])
+    {
+        $expression = array();
+
+        // Opening expression for array items ($1)
+        $expression[] = $this->buildArrayOpeningExpression($arrayItems);
+
+        // The target key opening
+        $expression[] = '(([\'"])' . $targetKey . '\3\s*=>\s*)';
+
+        // The method call
+        $expression[] = '(env\(([\'"]).*\5,\s*)([\'"])(.*)\6(\))';
 
         return '/' . implode('', $expression) . '/';
     }

--- a/tests/Config/RewriteTest.php
+++ b/tests/Config/RewriteTest.php
@@ -110,6 +110,18 @@ class RewriteTest extends TestCase
 
         $this->assertArrayHasKey('aNumber', $result);
         $this->assertEquals(69, $result['aNumber']);
+
+        /*
+         * Rewrite config with values from env
+         */
+        $contents = $writer->toContent($contents, [
+            'envMethod' => 'default',
+            'nestedEnv.envMethod.envChild' => 'default',
+        ]);
+        $result = eval('?>'.$contents);
+
+        $this->assertEquals('default', $result['envMethod']);
+        $this->assertEquals('default', $result['nestedEnv']['envMethod']['envChild']);
     }
 
 }

--- a/tests/fixtures/Config/sample-config.php
+++ b/tests/fixtures/Config/sample-config.php
@@ -23,6 +23,14 @@ return array(
 
     'aNumber' => 55,
 
+    'envMethod' => env('___KEY_FOR_ENV___', "unknown fallback value"),
+
+    'nestedEnv' => [
+        'envMethod' => [
+            'envChild' => env('___KEY_FOR_CHILD_ENV___', "unknown fallback child value"),
+        ],
+    ],
+
     /*
     |--------------------------------------------------------------------------
     | Application URL


### PR DESCRIPTION
It it common to have env method calls in config files. These should also be rewritable. To implement this I had to be able to use a specific replace pattern for each regex pattern. Currently rewriting .env/.env.example/.env.subtype is not supported. It just replaces the fallback value.

The problem originally occured in october https://github.com/octobercms/library/pull/397. As these libraries share the same code I added the pull requests to both libraries.