### PR TITLE
update illuminate/config to ^6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": ">=7.1.0",
-        "illuminate/config": "~5.0."
+        "illuminate/config": "^6.0."
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0"


### PR DESCRIPTION
When using Laravel 5.8 or above `illuminate/config` needs to be upgraded to a newer version.